### PR TITLE
Add sensor sampling ratio options

### DIFF
--- a/cartographer_fetch/configuration_files/freight.lua
+++ b/cartographer_fetch/configuration_files/freight.lua
@@ -32,6 +32,9 @@ options = {
   submap_publish_period_sec = 0.3,
   pose_publish_period_sec = 5e-3,
   trajectory_publish_period_sec = 30e-3,
+  rangefinder_sampling_ratio = 1.,
+  odometry_sampling_ratio = 1.,
+  imu_sampling_ratio = 1.,
 }
 
 MAP_BUILDER.use_trajectory_builder_2d = true

--- a/cartographer_fetch/configuration_files/freight_simulation.lua
+++ b/cartographer_fetch/configuration_files/freight_simulation.lua
@@ -32,6 +32,9 @@ options = {
   submap_publish_period_sec = 0.3,
   pose_publish_period_sec = 5e-3,
   trajectory_publish_period_sec = 30e-3,
+  rangefinder_sampling_ratio = 1.,
+  odometry_sampling_ratio = 1.,
+  imu_sampling_ratio = 1.,
 }
 
 MAP_BUILDER.use_trajectory_builder_2d = true


### PR DESCRIPTION
This PR adds the options introduced in [PR](https://github.com/googlecartographer/cartographer_ros/commit/3fab4ad6b619d13948fbf5cb1c363d6ff4c57f57) and sets them to a sampling ratio of 1 maintaining the original behavior.